### PR TITLE
Antlr parser semantics implementation

### DIFF
--- a/APi.py
+++ b/APi.py
@@ -27,8 +27,7 @@ Awkward π-nguin %s : Microservice orchestration language
 ------------------------------------------------------------
 ''' % __version__
 
-def process( stream ):
-    lexer = APiLexer( stream )
+def process( lexer ):
     lexer.recover = lambda x: sys.exit()
     stream = CommonTokenStream( lexer )
     parser = APiParser( stream )
@@ -36,10 +35,8 @@ def process( stream ):
     printer = APi()
     walker = ParseTreeWalker()
     walker.walk( printer, tree )
-    try:
-        return parser.STACK[ -1 ]
-    except:
-        pass # TODO: remove exception handling when all parts of parser are implemented
+    
+    return printer.get_ns()
     
 
 BYE = 'Bye!'
@@ -47,38 +44,21 @@ def main():
     if len( sys.argv ) > 2:
         print( 'Usage: APi [filename.api]' )
     else:
+        ns = None
+
         if len( sys.argv ) == 2:
             fl = sys.argv[ 1 ]
             stream = FileStream( fl, encoding='utf-8' )
-            process( stream )            
+            lexer = APiLexer( stream )
+            ns = process( lexer )
         else:
             print( splash )
-            while True:
-                try:
-                    command = input( "Aπ :- " )
-                except:
-                    print( '\n%s!' % BYE )
-                    quit_spade()
-                    sys.exit()
-                
-                if command == "exit":
-                    print( '%s!' % BYE )
-                    quit_spade()
-                    break
-                elif command == '':
-                    continue
-                elif command.strip()[ -1 ] == ':':
-                    line = input( '|' )
-                    command += '\n' + line
-                    while line[ 0 ] == '\t':
-                        line = input( '|' )
-                        command += '\n' + line
-                        if not line:
-                            break
-                    
-                if command:
-                    stream = InputStream( command + '\n' )
-                    process( stream )
+            lexer = APiLexer( StdinStream() )
+            ns = process( lexer )
+
+        print( ns )
+            
+            
 
 def initialize():
     global BYE

--- a/listener.py
+++ b/listener.py
@@ -15,6 +15,9 @@ class APi( APiListener ):
         self.STACK = []
         self.PARSING_XML = False
 
+    def get_ns( self ):
+        return self.ns
+
 
     # Enter a parse tree produced by APiParser#api_program.
     def enterApi_program(self, ctx:APiParser.Api_programContext):
@@ -27,11 +30,14 @@ class APi( APiListener ):
 
     # Enter a parse tree produced by APiParser#s_environment.
     def enterS_environment(self, ctx:APiParser.S_environmentContext):
-        pass
+        environment = { 'inputs': [], 'outputs': [] }
+        self.STACK.append( environment )
+
 
     # Exit a parse tree produced by APiParser#s_environment.
     def exitS_environment(self, ctx:APiParser.S_environmentContext):
-        pass
+        environment = self.STACK[ -1 ]
+        self.ns.add_environment( environment )
 
 
     # Enter a parse tree produced by APiParser#iflow.
@@ -40,16 +46,27 @@ class APi( APiListener ):
 
     # Exit a parse tree produced by APiParser#iflow.
     def exitIflow(self, ctx:APiParser.IflowContext):
-        pass
+        input_name = ctx.children[ 1 ].getText()
+        input_payload = self.STACK.pop()
+        input_flow = ( input_name, input_payload )
+
+        environment = self.STACK[ -1 ]
+        environment[ 'inputs' ].append( input_flow )
 
 
     # Enter a parse tree produced by APiParser#oflow.
     def enterOflow(self, ctx:APiParser.OflowContext):
         pass
 
+
     # Exit a parse tree produced by APiParser#oflow.
     def exitOflow(self, ctx:APiParser.OflowContext):
-        pass
+        output_name = ctx.children[ 1 ].getText()
+        output_payload = self.STACK.pop()
+        output_flow = ( output_name, output_payload )
+
+        environment = self.STACK[ -1 ]
+        environment[ 'outputs' ].append( output_flow )
 
 
     # Enter a parse tree produced by APiParser#s_start.
@@ -72,16 +89,23 @@ class APi( APiListener ):
 
     # Enter a parse tree produced by APiParser#s_agent.
     def enterS_agent(self, ctx:APiParser.S_agentContext):
-        pass
+        agent_name = ctx.children[ 1 ].getText()
+        agent = { 'name': agent_name, 'flows': [] }
+
+        self.STACK.append(agent)
+
 
     # Exit a parse tree produced by APiParser#s_agent.
     def exitS_agent(self, ctx:APiParser.S_agentContext):
-        pass
+        agent = self.STACK[ -1 ]
+        self.ns.add_agent( agent )
 
 
     # Enter a parse tree produced by APiParser#arglist.
     def enterArglist(self, ctx:APiParser.ArglistContext):
-        pass
+        agent = self.STACK[ -1 ]
+        args = [ ctx.children[ i ].getText() for i in range( 1, len( ctx.children ) - 1 ) ]
+        agent[ 'args' ] = args
 
     # Exit a parse tree produced by APiParser#arglist.
     def exitArglist(self, ctx:APiParser.ArglistContext):
@@ -94,12 +118,18 @@ class APi( APiListener ):
 
     # Exit a parse tree produced by APiParser#flow.
     def exitFlow(self, ctx:APiParser.FlowContext):
-        pass
+        flow = []
+        while ( type(self.STACK[ -1 ] ) is not dict ):
+            channel_name = self.STACK.pop().getText()
+            flow.insert( 0, channel_name )
 
+        agent = self.STACK[ -1 ]
+        agent[ 'flows' ].append( flow )
 
     # Enter a parse tree produced by APiParser#valid_channel.
     def enterValid_channel(self, ctx:APiParser.Valid_channelContext):
-        pass
+        channel_name = ctx.children[ 0 ]
+        self.STACK.append( channel_name )
 
     # Exit a parse tree produced by APiParser#valid_channel.
     def exitValid_channel(self, ctx:APiParser.Valid_channelContext):
@@ -108,11 +138,15 @@ class APi( APiListener ):
 
     # Enter a parse tree produced by APiParser#s_channel.
     def enterS_channel(self, ctx:APiParser.S_channelContext):
-        pass
+        channel_name = ctx.children[ 1 ].getText()
+        agent = { 'name': channel_name }
+
+        self.STACK.append( agent )
 
     # Exit a parse tree produced by APiParser#s_channel.
     def exitS_channel(self, ctx:APiParser.S_channelContext):
-        pass
+        channel = self.STACK[ -1 ]
+        self.ns.add_channel( channel )
 
 
     # Enter a parse tree produced by APiParser#s_channel_transformer.
@@ -130,7 +164,12 @@ class APi( APiListener ):
 
     # Exit a parse tree produced by APiParser#s_channel_spec.
     def exitS_channel_spec(self, ctx:APiParser.S_channel_specContext):
-        pass
+        output_payload = self.STACK.pop()
+        input_payload = self.STACK.pop()
+        channel = self.STACK[ -1 ]
+        
+        channel[ 'input' ] = input_payload
+        channel[ 'output' ] = output_payload
 
 
     # Enter a parse tree produced by APiParser#s_import.
@@ -139,12 +178,15 @@ class APi( APiListener ):
 
     # Exit a parse tree produced by APiParser#s_import.
     def exitS_import(self, ctx:APiParser.S_importContext):
-        pass
+        holon_name = ctx.children[ 1 ].getText()
+        self.ns.add_holon( holon_name )
 
 
     # Enter a parse tree produced by APiParser#s_input.
     def enterS_input(self, ctx:APiParser.S_inputContext):
-        pass
+        input_payload = ctx.children[ 0 ].getText()
+        self.STACK.append( input_payload )
+
 
     # Exit a parse tree produced by APiParser#s_input.
     def exitS_input(self, ctx:APiParser.S_inputContext):
@@ -153,7 +195,9 @@ class APi( APiListener ):
 
     # Enter a parse tree produced by APiParser#s_output.
     def enterS_output(self, ctx:APiParser.S_outputContext):
-        pass
+        output_payload = ctx.children[ 0 ].getText()
+        self.STACK.append( output_payload )
+
 
     # Exit a parse tree produced by APiParser#s_output.
     def exitS_output(self, ctx:APiParser.S_outputContext):
@@ -180,7 +224,8 @@ class APi( APiListener ):
 
     # Enter a parse tree produced by APiParser#s_regex.
     def enterS_regex(self, ctx:APiParser.S_regexContext):
-        self.STACK.append( 'regex( ' + ctx.children[ 1 ].getText()[ 1:-1 ] + ' )' )
+        # self.STACK.append( 'regex( ' + ctx.children[ 1 ].getText()[ 1:-1 ] + ' )' )
+        pass
 
 
     # Exit a parse tree produced by APiParser#s_regex.
@@ -191,87 +236,96 @@ class APi( APiListener ):
     # Enter a parse tree produced by APiParser#json.
     def enterJson(self, ctx:APiParser.JsonContext):
         try:
-            print( ctx.children[ 0 ].getText() )
+            # print( ctx.children[ 0 ].getText() )
+            pass
         except:
             pass
 
     # Exit a parse tree produced by APiParser#json.
     def exitJson(self, ctx:APiParser.JsonContext):
-        top = self.STACK.pop()
-        self.STACK.append( 'json( %s )' % top )
-        print( self.STACK[ -1 ] )
+        # top = self.STACK.pop()
+        # self.STACK.append( 'json( %s )' % top )
+        # print( self.STACK[ -1 ] )
+        pass
 
     # Enter a parse tree produced by APiParser#obj.
     def enterObj(self, ctx:APiParser.ObjContext):
-        self.STACK.append( 'api_object_begin' )
+        # self.STACK.append( 'api_object_begin' )
+        pass
 
     # Exit a parse tree produced by APiParser#obj.
     def exitObj(self, ctx:APiParser.ObjContext):
-        prolog = 'object( '
-        pair = None
-        res = []
-        while pair != 'api_object_begin':
-            pair = self.STACK.pop()
-            if pair != 'api_object_begin':
-                res.append( pair )
-        res.reverse()
-        for val in res:
-            prolog += "%s, " % val
-        prolog = prolog[ :-2 ] + ' )'
-        self.STACK.append( prolog )
+        # prolog = 'object( '
+        # pair = None
+        # res = []
+        # while pair != 'api_object_begin':
+        #     pair = self.STACK.pop()
+        #     if pair != 'api_object_begin':
+        #         res.append( pair )
+        # res.reverse()
+        # for val in res:
+        #     prolog += "%s, " % val
+        # prolog = prolog[ :-2 ] + ' )'
+        # self.STACK.append( prolog )
+        pass
 
 
     # Enter a parse tree produced by APiParser#pair.
     def enterPair(self, ctx:APiParser.PairContext):
-        self.STACK.append( 'pair' )
-        ch = ctx.children[ 0 ].getText()
-        if ch[ 0 ] in [ "'", '"' ]:
-            val = "'string:%s'" % ch[ 1:-1 ]
-        elif ch[ 0 ] == '?':
-            val = 'X' + ch[ 1: ]
-        self.STACK.append( val )
+        # self.STACK.append( 'pair' )
+        # ch = ctx.children[ 0 ].getText()
+        # if ch[ 0 ] in [ "'", '"' ]:
+        #     val = "'string:%s'" % ch[ 1:-1 ]
+        # elif ch[ 0 ] == '?':
+        #     val = 'X' + ch[ 1: ]
+        # self.STACK.append( val )
+        pass
 
     # Exit a parse tree produced by APiParser#pair.
     def exitPair(self, ctx:APiParser.PairContext):
-        val = self.STACK.pop()
-        key = self.STACK.pop()
-        self.STACK.pop()
-        self.STACK.append( "pair( %s, %s )" % ( key, val ) )
+        # val = self.STACK.pop()
+        # key = self.STACK.pop()
+        # self.STACK.pop()
+        # self.STACK.append( "pair( %s, %s )" % ( key, val ) )
+        pass
 
 
     # Enter a parse tree produced by APiParser#arr.
     def enterArr(self, ctx:APiParser.ArrContext):
-        self.STACK.append( 'api_array_begin' )
+        # self.STACK.append( 'api_array_begin' )
+        pass
         
     # Exit a parse tree produced by APiParser#arr.
     def exitArr(self, ctx:APiParser.ArrContext):
-        val = None
-        prolog = 'array( ['
-        res = []
-        while val != 'api_array_begin':
-            val = self.STACK.pop()
-            if val != 'api_array_begin':
-                res.append( val )
-        res.reverse()
-        for val in res:
-            prolog += "%s, " % val
-        prolog = prolog[ :-2 ] + ' ] )'
-        self.STACK.append( prolog )
+        # val = None
+        # prolog = 'array( ['
+        # res = []
+        # while val != 'api_array_begin':
+        #     val = self.STACK.pop()
+        #     if val != 'api_array_begin':
+        #         res.append( val )
+        # res.reverse()
+        # for val in res:
+        #     prolog += "%s, " % val
+        # prolog = prolog[ :-2 ] + ' ] )'
+        # self.STACK.append( prolog )
+        pass
         
 
 
     # Enter a parse tree produced by APiParser#value.
     def enterValue(self, ctx:APiParser.ValueContext):
-        if not self.PARSING_XML:
-            val = ctx.getText()
-            if ctx.VARIABLE():
-                self.STACK.append( 'X' + val[ 1: ] )
-            elif ctx.STRING():
-                self.STACK.append( "'string:%s'" % val[ 1:-1 ] )
-            elif ctx.NUMBER():
-                self.STACK.append( "'number:%s'" % val )
-            elif val in [ 'true', 'false', 'null' ]:
-                self.STACK.append( "'atom:%s'" % val )
+        # if not self.PARSING_XML:
+        #     val = ctx.getText()
+        #     if ctx.VARIABLE():
+        #         self.STACK.append( 'X' + val[ 1: ] )
+        #     elif ctx.STRING():
+        #         self.STACK.append( "'string:%s'" % val[ 1:-1 ] )
+        #     elif ctx.NUMBER():
+        #         self.STACK.append( "'number:%s'" % val )
+        #     elif val in [ 'true', 'false', 'null' ]:
+        #         self.STACK.append( "'atom:%s'" % val )
+        pass
 
     # Exit a parse tree produced by APiParser#value.
     def exitValue(self, ctx:APiParser.ValueContext):
@@ -280,84 +334,92 @@ class APi( APiListener ):
 
     # Enter a parse tree produced by APiParser#xml.
     def enterXml(self, ctx:APiParser.XmlContext):
-        self.STACK.append( 'xml' )
+        # self.STACK.append( 'xml' )
+        pass
 
     # Exit a parse tree produced by APiParser#xml.
     def exitXml(self, ctx:APiParser.XmlContext):
-        top = self.STACK.pop()
-        self.STACK.append( 'xml( %s )' % top )
-        print( self.STACK[ -1 ] )
+        # top = self.STACK.pop()
+        # self.STACK.append( 'xml( %s )' % top )
+        # print( self.STACK[ -1 ] )
+        pass
 
 
     # Enter a parse tree produced by APiParser#prolog.
     def enterProlog(self, ctx:APiParser.PrologContext):
-        self.STACK.append( 'api_prolog_begin' )
+        # self.STACK.append( 'api_prolog_begin' )
+        pass
 
     # Exit a parse tree produced by APiParser#prolog.
     def exitProlog(self, ctx:APiParser.PrologContext):
-        val = None
-        prolog = 'prolog( '
-        res = []
-        while val != 'api_prolog_begin':
-            val = self.STACK.pop()
-            if val != 'api_prolog_begin':
-                res.append( val )
-        res.reverse()
-        for val in res:
-            prolog += '%s, ' % val
-        prolog = prolog[ :-2 ] + ' )'
-        self.STACK.append( prolog )
+        # val = None
+        # prolog = 'prolog( '
+        # res = []
+        # while val != 'api_prolog_begin':
+        #     val = self.STACK.pop()
+        #     if val != 'api_prolog_begin':
+        #         res.append( val )
+        # res.reverse()
+        # for val in res:
+        #     prolog += '%s, ' % val
+        # prolog = prolog[ :-2 ] + ' )'
+        # self.STACK.append( prolog )
+        pass
 
 
     # Enter a parse tree produced by APiParser#content.
     def enterContent(self, ctx:APiParser.ContentContext):
-        self.STACK.append( 'api_content_begin' )
+        # self.STACK.append( 'api_content_begin' )
+        pass
 
     # Exit a parse tree produced by APiParser#content.
     def exitContent(self, ctx:APiParser.ContentContext):
-        val = None
-        prolog = 'content( '
-        res = []
-        while val != 'api_content_begin':
-            val = self.STACK.pop()
-            if val != 'api_content_begin':
-                res.append( val )
-        res.reverse()
-        for val in res:
-            prolog += '%s, ' % val
-        prolog = prolog[ :-2 ] + ' )'
-        self.STACK.append( prolog )
+        # val = None
+        # prolog = 'content( '
+        # res = []
+        # while val != 'api_content_begin':
+        #     val = self.STACK.pop()
+        #     if val != 'api_content_begin':
+        #         res.append( val )
+        # res.reverse()
+        # for val in res:
+        #     prolog += '%s, ' % val
+        # prolog = prolog[ :-2 ] + ' )'
+        # self.STACK.append( prolog )
+        pass
 
 
     # Enter a parse tree produced by APiParser#element.
     def enterElement(self, ctx:APiParser.ElementContext):
-        self.STACK.append( 'api_element_begin' )
+        # self.STACK.append( 'api_element_begin' )
+        pass
 
     # Exit a parse tree produced by APiParser#element.
     def exitElement(self, ctx:APiParser.ElementContext):
-        val = None
-        prolog = 'element( '
-        res = []
-        while val != 'api_element_begin':
-            val = self.STACK.pop()
-            if val != 'api_element_begin':
-                res.append( val )
-        elem_name = res.pop()
-        prolog += 'elem( %s ), ' % elem_name
-        res.reverse()
-        for val in res:
-            prolog += '%s, ' % val
-        prolog = prolog[ :-2 ] + ' )'
-        self.STACK.append( prolog )
-
+        # val = None
+        # prolog = 'element( '
+        # res = []
+        # while val != 'api_element_begin':
+        #     val = self.STACK.pop()
+        #     if val != 'api_element_begin':
+        #         res.append( val )
+        # elem_name = res.pop()
+        # prolog += 'elem( %s ), ' % elem_name
+        # res.reverse()
+        # for val in res:
+        #     prolog += '%s, ' % val
+        # prolog = prolog[ :-2 ] + ' )'
+        # self.STACK.append( prolog )
+        pass
 
     # Enter a parse tree produced by APiParser#var_or_ident.
     def enterVar_or_ident(self, ctx:APiParser.Var_or_identContext):
-        val = ctx.getText()
-        if ctx.IDENT():
-            self.STACK.append( "'ident:%s'" % val )
-        elif ctx.VARIABLE():
-            self.STACK.append( 'X' + val[ 1: ] )
+        # val = ctx.getText()
+        # if ctx.IDENT():
+        #     self.STACK.append( "'ident:%s'" % val )
+        # elif ctx.VARIABLE():
+        #     self.STACK.append( 'X' + val[ 1: ] )
+        pass
 
     # Exit a parse tree produced by APiParser#var_or_ident.
     def exitVar_or_ident(self, ctx:APiParser.Var_or_identContext):
@@ -375,38 +437,41 @@ class APi( APiListener ):
 
     # Enter a parse tree produced by APiParser#attribute.
     def enterAttribute(self, ctx:APiParser.AttributeContext):
-        self.STACK.append( 'api_attribute_begin' )
-        ch = ctx.children[ 2 ].getText()
-        if ch[ 0 ] in [ "'", '"' ]:
-            val = "'string:%s'" % ch[ 1:-1 ]
-        elif ch[ 0 ] == '?':
-            val = 'X' + ch[ 1: ]
-        self.STACK.append( val )
+        # self.STACK.append( 'api_attribute_begin' )
+        # ch = ctx.children[ 2 ].getText()
+        # if ch[ 0 ] in [ "'", '"' ]:
+        #     val = "'string:%s'" % ch[ 1:-1 ]
+        # elif ch[ 0 ] == '?':
+        #     val = 'X' + ch[ 1: ]
+        # self.STACK.append( val )
+        pass
 
     # Exit a parse tree produced by APiParser#attribute.
     def exitAttribute(self, ctx:APiParser.AttributeContext):
-        val = None
-        prolog = 'attribute( '
-        res = []
-        while val != 'api_attribute_begin':
-            val = self.STACK.pop()
-            if val != 'api_attribute_begin':
-                res.append( val )
-        for val in res:
-            prolog += '%s, ' % val
-        prolog = prolog[ :-2 ] + ' )'
-        self.STACK.append( prolog )
+        # val = None
+        # prolog = 'attribute( '
+        # res = []
+        # while val != 'api_attribute_begin':
+        #     val = self.STACK.pop()
+        #     if val != 'api_attribute_begin':
+        #         res.append( val )
+        # for val in res:
+        #     prolog += '%s, ' % val
+        # prolog = prolog[ :-2 ] + ' )'
+        # self.STACK.append( prolog )
+        pass
 
 
     # Enter a parse tree produced by APiParser#chardata.
     def enterChardata(self, ctx:APiParser.ChardataContext):
         # TODO: This is a hackish solution. There must be a more elegant one.
-        values = [ i.getText() for i in ctx.children ]
-        for val in values:
-            if val[ 0 ] == '?':
-                self.STACK.append( 'X' + val[ 1: ] )
-            else:
-                self.STACK.append( "'atom:%s'" % val )
+        # values = [ i.getText() for i in ctx.children ]
+        # for val in values:
+        #     if val[ 0 ] == '?':
+        #         self.STACK.append( 'X' + val[ 1: ] )
+        #     else:
+        #         self.STACK.append( "'atom:%s'" % val )
+        pass
 
         
             

--- a/namespace.py
+++ b/namespace.py
@@ -6,7 +6,19 @@ class APiNamespace( dict ):
     environment and holon identifiers.
     '''
     def __init__( self, *args, **kwargs ):
-        self[ 'agents' ] = {}
-        self[ 'channels' ] = {}
-        self[ 'environment' ] = {}
-        self[ 'holons' ] = {}
+        self[ 'agents' ] = []
+        self[ 'channels' ] = []
+        self[ 'environment' ] = []
+        self[ 'holons' ] = []
+
+    def add_agent ( self, agent ):
+        self[ 'agents' ].append( agent )    
+        
+    def add_channel ( self, channel ):
+        self[ 'channels' ].append( channel )    
+        
+    def add_environment ( self, environment ):
+        self[ 'environment' ].append( environment )
+
+    def add_holon( self, name ):
+        self[ 'holons' ].append( name )


### PR DESCRIPTION
**Description**
This PR implements parser semantics in order to convert communication specification into a format that APi platform may work with. User can parse specification either by: 1.) supplying `*.api` file name, 2.) writing directly into the shell.

**Notes**
1. I have removed JSON / XML parser semantics because it will be more useful for us to keep plain JSON / XML and then use corresponding libraries for reading the content
2. May there be multiple environments or only a single one?
3. May the environment have multiple inputs / outputs or just a single one?
4. For some reason, the parser gets stuck when it encounters empty block / row (`\n\n`) thus communication specification must be white empty blocks / rows