### PR TITLE
Gracefully shutdown agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 RUN pip3 install git+https://github.com/AILab-FOI/pyxf
 RUN pip3 install --upgrade aiohttp_jinja2
+RUN pip3 install spade==3.2.3

--- a/agent.py
+++ b/agent.py
@@ -705,12 +705,12 @@ class APiAgent( APiBaseAgent ):
 
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error getting channel address due to ' + msg.metadata[ 'reson' ] )
-                            self.kill()
+                            await self.agent.stop()
                         elif msg.metadata[ 'success' ] == 'true':
                             self.agent.address_book[ msg.metadata[ 'agent' ] ] = channel
                         else:
                             self.agent.say( 'Error getting channel address. Channel unknown to holon.' )
-                            self.kill()
+                            await self.agent.stop()
                             
                     except KeyError:
                         self.agent.say( 'I have no memory of this message (%s). (awkward Gandalf look)' % msg.metadata[ 'in-reply-to' ] )           
@@ -731,7 +731,7 @@ class APiAgent( APiBaseAgent ):
                         self.agent.input_ack.remove( msg.metadata[ 'in-reply-to' ] )
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error connecting to channel address due to ' + msg.metadata[ 'reason' ] )
-                            self.kill()
+                            await self.agent.stop()
                         else:
                             channel = msg.metadata[ 'agent' ]
                             is_udp = msg.metadata[ 'protocol' ] == 'udp'
@@ -770,7 +770,7 @@ class APiAgent( APiBaseAgent ):
                         self.agent.input_ack.remove( msg.metadata[ 'in-reply-to' ] )
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error connecting to channel address due to ' + msg.metadata[ 'reason' ] )
-                            self.kill() # TODO: Inform holon about failure
+                            await self.agent.stop() # TODO: Inform holon about failure
                         else:
                             channel = msg.metadata[ 'agent' ]
                             is_udp = msg.metadata['protocol'] == 'udp'

--- a/agent.py
+++ b/agent.py
@@ -2,6 +2,7 @@
 from baseagent import *
 import json
 import argparse
+import time
 
 class APiAgent( APiBaseAgent ):
     '''Service wrapper agent.'''
@@ -183,6 +184,14 @@ class APiAgent( APiBaseAgent ):
             self.wsws_thread = None
             self.wsnc_thread = None
             self.wsncrec_thread = None
+
+            # NC threads
+            self.ncstdout_thread = None
+            self.ncfile_thread = None
+            self.nchttp_thread = None
+            self.ncws_thread = None
+            self.ncnc_thread = None
+            self.ncncrec_thread = None
             
             try:
                 self.process_descriptor()
@@ -225,7 +234,7 @@ class APiAgent( APiBaseAgent ):
                     print( 'TRYING TO RECONNECT' )
                     srv[ 'socket' ] = nclib.Netcat( ( srv[ 'server' ], srv[ 'port' ] ), udp=is_udp )
         if data == self.output_delimiter: # TODO: Verify this
-            await self.service_quit( 'End of output' )
+            self.service_quit( 'End of output' )
                     
 
     def subscribe_to_channel( self, channel, channel_type ):
@@ -831,6 +840,15 @@ def main( name, address, password, holon, holon_name, token, flows, holons_addre
     a = APiAgent( name, address, password, holon, holon_name, token, flows, holons_address_book )
     
     a.start()
+
+    # is_alive() might return false on first check, as agent won't be yet starter
+    # thus there is is_init_set flag which will ensure that we wait for is_alive() to
+    # return true at least once before we would even expect is_alive() to return truthy false
+    is_init_set = False
+    while a.is_alive() or not is_init_set:
+        if a.is_alive():
+            is_init_set = True
+        time.sleep(1)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser( description='APi agent.')

--- a/agent.py
+++ b/agent.py
@@ -705,12 +705,12 @@ class APiAgent( APiBaseAgent ):
 
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error getting channel address due to ' + msg.metadata[ 'reson' ] )
-                            await self.agent.stop()
+                            await self.stop()
                         elif msg.metadata[ 'success' ] == 'true':
                             self.agent.address_book[ msg.metadata[ 'agent' ] ] = channel
                         else:
                             self.agent.say( 'Error getting channel address. Channel unknown to holon.' )
-                            await self.agent.stop()
+                            await self.stop()
                             
                     except KeyError:
                         self.agent.say( 'I have no memory of this message (%s). (awkward Gandalf look)' % msg.metadata[ 'in-reply-to' ] )           
@@ -731,7 +731,7 @@ class APiAgent( APiBaseAgent ):
                         self.agent.input_ack.remove( msg.metadata[ 'in-reply-to' ] )
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error connecting to channel address due to ' + msg.metadata[ 'reason' ] )
-                            await self.agent.stop()
+                            await self.stop()
                         else:
                             channel = msg.metadata[ 'agent' ]
                             is_udp = msg.metadata[ 'protocol' ] == 'udp'
@@ -770,7 +770,7 @@ class APiAgent( APiBaseAgent ):
                         self.agent.input_ack.remove( msg.metadata[ 'in-reply-to' ] )
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error connecting to channel address due to ' + msg.metadata[ 'reason' ] )
-                            await self.agent.stop() # TODO: Inform holon about failure
+                            await self.stop() # TODO: Inform holon about failure
                         else:
                             channel = msg.metadata[ 'agent' ]
                             is_udp = msg.metadata['protocol'] == 'udp'

--- a/agent.py
+++ b/agent.py
@@ -705,12 +705,12 @@ class APiAgent( APiBaseAgent ):
 
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error getting channel address due to ' + msg.metadata[ 'reson' ] )
-                            await self.stop()
+                            await self.agent.stop()
                         elif msg.metadata[ 'success' ] == 'true':
                             self.agent.address_book[ msg.metadata[ 'agent' ] ] = channel
                         else:
                             self.agent.say( 'Error getting channel address. Channel unknown to holon.' )
-                            await self.stop()
+                            await self.agent.stop()
                             
                     except KeyError:
                         self.agent.say( 'I have no memory of this message (%s). (awkward Gandalf look)' % msg.metadata[ 'in-reply-to' ] )           
@@ -731,7 +731,7 @@ class APiAgent( APiBaseAgent ):
                         self.agent.input_ack.remove( msg.metadata[ 'in-reply-to' ] )
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error connecting to channel address due to ' + msg.metadata[ 'reason' ] )
-                            await self.stop()
+                            await self.agent.stop()
                         else:
                             channel = msg.metadata[ 'agent' ]
                             is_udp = msg.metadata[ 'protocol' ] == 'udp'
@@ -770,7 +770,7 @@ class APiAgent( APiBaseAgent ):
                         self.agent.input_ack.remove( msg.metadata[ 'in-reply-to' ] )
                         if msg.metadata[ 'performative' ] == 'refuse':
                             self.agent.say( 'Error connecting to channel address due to ' + msg.metadata[ 'reason' ] )
-                            await self.stop() # TODO: Inform holon about failure
+                            await self.agent.stop() # TODO: Inform holon about failure
                         else:
                             channel = msg.metadata[ 'agent' ]
                             is_udp = msg.metadata['protocol'] == 'udp'

--- a/baseagent.py
+++ b/baseagent.py
@@ -107,10 +107,6 @@ class APiTalkingAgent( Agent ):
         bt = self.Terminate()
         self.add_behaviour( bt, bt_template )
 
-    def on_end(self):
-        print("in")
-        # sys.exit(1)
-
     async def schedule_message( self, to, body='', metadata={} ):
         # TODO: See if this can be done in a more elegant way ...
         msg = Message( to=to, body=body, metadata=deepcopy( metadata ) )
@@ -296,7 +292,7 @@ class APiBaseAgent( APiTalkingAgent ):
         stdin - STDIN file handle
         '''
         send = True
-        while send and self.input_ended == False:
+        while send:
             if not self.BUFFER:
                 await asyncio.sleep( 0.1 )
             else:
@@ -818,21 +814,15 @@ class APiBaseAgent( APiTalkingAgent ):
         while not self.all_setup():
             await asyncio.sleep( 0.1 )
 
-        print("prosoo")
-
         proc = await asyncio.create_subprocess_shell(
             cmd,
             stderr=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE )
 
-        print("hey")
-
         await asyncio.gather(
             self.read_stderr( proc.stderr ),
             self.read_stdout( proc.stdout ) )
     
-        print("holjan")
-
         try:
             pid = proc.pid
             pr = psutil.Process( pid )
@@ -1435,7 +1425,6 @@ class APiBaseAgent( APiTalkingAgent ):
             self.nc_udp = udp != ''
             self.input = self.input_nc
             
-            print("ever here?")
             self.ncstdout_thread = Thread( target=asyncio.run, args=( self.input_ncstdout_run( self.cmd ), ) )
             #self.ncstdout_thread.start()
 

--- a/baseagent.py
+++ b/baseagent.py
@@ -137,8 +137,7 @@ class APiTalkingAgent( Agent ):
                     metadata[ 'status' ] = 'stopped'
                     await self.agent.schedule_message( self.agent.holon, metadata=metadata )
 
-                    # or should we use super().stop()?
-                    self.kill()
+                    await self.agent.stop()
                 else:
                     self.agent.say( 'Message could not be verified. IMPOSTER!!!!!!' )
 
@@ -146,9 +145,7 @@ class APiTalkingAgent( Agent ):
         async def run(self):
             msg = await self.receive( timeout=1 )
             if msg:
-                print("to je to")
                 if self.agent.verify( msg ):
-                    print("ina")
                     await self.agent.stop()
                 else:
                     self.agent.say( 'Message could not be verified. IMPOSTER!!!!!!' )

--- a/baseagent.py
+++ b/baseagent.py
@@ -822,7 +822,7 @@ class APiBaseAgent( APiTalkingAgent ):
         await asyncio.gather(
             self.read_stderr( proc.stderr ),
             self.read_stdout( proc.stdout ) )
-    
+
         try:
             pid = proc.pid
             pr = psutil.Process( pid )

--- a/channel.py
+++ b/channel.py
@@ -2,6 +2,7 @@
 
 from basechannel import *
 import json
+import time
 import argparse
 
 class APiChannel( APiBaseChannel ):
@@ -181,7 +182,17 @@ def main( name, address, password, holon, token, portrange, protocol, input, out
     input = json.loads( input )
     output = json.loads( output )
     a = APiChannel( name, address, password, holon, token, portrange, protocol=protocol, channel_input=input, channel_output=output )
+    
     a.start()
+
+    # is_alive() might return false on first check, as agent won't be yet starter
+    # thus there is is_init_set flag which will ensure that we wait for is_alive() to
+    # return true at least once before we would even expect is_alive() to return truthy false
+    is_init_set = False
+    while a.is_alive() or not is_init_set:
+        if a.is_alive():
+            is_init_set = True
+        time.sleep(1)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser( description='APi agent.')

--- a/environment.py
+++ b/environment.py
@@ -2,6 +2,7 @@
 
 from basechannel import *
 import json
+import time
 import argparse
 
 class APiEnvironment( APiBaseChannel ):
@@ -227,6 +228,15 @@ def main( name, address, password, holon, holon_name, token, portrange, input_pr
     output = json.loads( output )
     a = APiEnvironment( name, address, password, holon, holon_name, token, portrange, input_protocol, output_protocol, input, output )
     a.start()
+
+    # is_alive() might return false on first check, as agent won't be yet starter
+    # thus there is is_init_set flag which will ensure that we wait for is_alive() to
+    # return true at least once before we would even expect is_alive() to return truthy false
+    is_init_set = False
+    while a.is_alive() or not is_init_set:
+        if a.is_alive():
+            is_init_set = True
+        time.sleep(1)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser( description='APi agent.')

--- a/holon.py
+++ b/holon.py
@@ -40,7 +40,7 @@ class APiHolon( APiTalkingAgent ):
         self.all_agents_listening = False
 
         self.all_started = False # Indicate if execution plan has been started already
-        self.start_env_and_channels_all()
+        self.start_env_and_channels()
 
         self.query_message_template = {}
         self.query_message_template[ 'performative' ] = 'inform-ref'
@@ -152,11 +152,11 @@ class APiHolon( APiTalkingAgent ):
     def start_dependant_agent_thread( self, a_id, plan_id, cmd ):
         proc = sp.Popen( cmd, start_new_session=True )
         proc.communicate()
-        return_code = proc.returncode
+        return_code = proc.returncode        
 
         self.agent_finished(a_id, plan_id, return_code)
 
-    def start_env_and_channels_all( self ):
+    def start_env_and_channels( self ):
         if not self.environment == None:
             cmd = shlex.split( self.environment[ 'cmd' ] )
             self.say('Running environment:', self.environment.get('name'))
@@ -436,6 +436,7 @@ class APiHolon( APiTalkingAgent ):
                     
                     # sending message to ack that agent has stopped, so they can terminate
                     metadata = deepcopy( self.agent.confirm_message_template )
+                    metadata[ 'action' ] = 'finish'
                     metadata[ 'in-reply-to' ] = msg.metadata[ 'reply-with' ]
 
                     await self.agent.schedule_message( str( msg.sender ), metadata=metadata )


### PR DESCRIPTION
**Description**
Making sure we gracefully shut down agents and their threads when they are done doing their work or if holon sends them stop message

**List of changes**
- upgrading spade version as in previous versions, process could not shutdown properly unless it is force-killed
- more adequate approach to listening for agent stopping (which removes circular dependency)